### PR TITLE
Add test for PPM save

### DIFF
--- a/pytracer/canvas.py
+++ b/pytracer/canvas.py
@@ -1,6 +1,16 @@
 from .color import Color
 
 
+class DummyPoint:
+    """
+    Adding this to see how Coveralls reports on new, untested code.
+    """
+
+    def __init__(self, x: int, y: int):
+        self.x = x
+        self.y = y
+
+
 class Canvas:
     def __init__(self, width: int, height: int, fill=Color(0, 0, 0)):
         self.width = width

--- a/pytracer/canvas.py
+++ b/pytracer/canvas.py
@@ -1,16 +1,6 @@
 from .color import Color
 
 
-class DummyPoint:
-    """
-    Adding this to see how Coveralls reports on new, untested code.
-    """
-
-    def __init__(self, x: int, y: int):
-        self.x = x
-        self.y = y
-
-
 class Canvas:
     def __init__(self, width: int, height: int, fill=Color(0, 0, 0)):
         self.width = width

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -35,25 +35,25 @@ def test_ppm_pixel_data():
     assert ppm_lines[5] == "\n"
 
 
-# def test_save():
-#     c = Canvas(2, 2)
-#     c.write_pixel(0, 0, Color(0.5, 0.5, 0.5))
-#     c.write_pixel(1, 1, Color(1, 1, 1))
-#     dest = StringIO()
+def test_save():
+    c = Canvas(2, 2)
+    c.write_pixel(0, 0, Color(0.5, 0.5, 0.5))
+    c.write_pixel(1, 1, Color(1, 1, 1))
+    dest = StringIO()
 
-#     PPM.save(c, dest)
+    PPM.save(c, dest)
 
-#     print(dest.getvalue())
+    print(dest.getvalue())
 
-#     expected = dedent(
-#         """
-#         P3
-#         2 2
-#         255
-#         128 128 128 0 0 0 0 0 0 255 255 255
+    expected = dedent(
+        """
+        P3
+        2 2
+        255
+        128 128 128 0 0 0 0 0 0 255 255 255
 
 
-#         """
-#     ).lstrip()  # removes leading whitespace for nicer formatting here
+        """
+    ).lstrip()  # removes leading whitespace for nicer formatting here
 
-#     assert dest.getvalue() == expected
+    assert dest.getvalue() == expected


### PR DESCRIPTION
This PR shows coveralls reporting of two changes:

* Added a test to increase existing coverage of `pytracer/image.py`
* Added some new, untested code.


Setup notes:

GH action setup guide here: https://github.com/marketplace/actions/coveralls-github-action. It's really simple, just this:

```yaml
      - name: coveralls
        uses: coverallsapp/github-action@v2
```


Have to add `COVERALLS_REPO_TOKEN` as a repository secret. It seems each repo gets its own token.

Have to enable comments in the repo settings:

<img width="658" alt="image" src="https://github.com/chrislawlor/pytracer/assets/238952/60039a6d-a34b-4670-abbb-d6926a7c9a0a">

I also had to add the @coveralls user, to allow it to add comments.


PR comments didn't seem to work right away, and they take about a min or so to show up. Subsequent commits overwrite the previous comment, which is nice.


## Other notes

This repo didn't have any CI set up, so I borrowed most of the GH action setup from https://jacobian.org/til/github-actions-poetry/.